### PR TITLE
use 2-legged client auth

### DIFF
--- a/unsplash/unsplash_test.go
+++ b/unsplash/unsplash_test.go
@@ -24,6 +24,7 @@
 package unsplash
 
 import (
+	"math/rand"
 	"context"
 	"encoding/json"
 	"io/ioutil"
@@ -35,6 +36,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2/clientcredentials"
 )
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 type AuthConfig struct {
 	AppID, Secret, AuthToken string
@@ -52,6 +55,7 @@ func authFromFile() *AuthConfig {
 	}
 	return &config
 }
+
 func getAppAuth() *AuthConfig {
 	var config AuthConfig
 	appID, ok := os.LookupEnv("unsplash_appID")
@@ -60,6 +64,14 @@ func getAppAuth() *AuthConfig {
 	}
 	config.AppID = appID
 	return &config
+}
+
+func randCollectionName(n int) string {
+    b := make([]rune, n)
+    for i := range b {
+        b[i] = letters[rand.Intn(len(letters))]
+    }
+    return string(b)
 }
 
 func getUserAuth() *AuthConfig {

--- a/unsplash/unsplash_test.go
+++ b/unsplash/unsplash_test.go
@@ -24,6 +24,7 @@
 package unsplash
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -32,7 +33,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 type AuthConfig struct {
@@ -86,11 +87,12 @@ func setup() *Unsplash {
 			os.Exit(1)
 		}
 	}
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: c.AuthToken},
-	)
-	client := oauth2.NewClient(oauth2.NoContext, ts)
-	return New(client)
+	client := clientcredentials.Config{
+		ClientID: c.AppID,
+		ClientSecret: c.Secret,
+		TokenURL: "https://unsplash.com/oauth/token",
+	}
+	return New(client.Client(context.Background()))
 }
 func TestUnsplash(T *testing.T) {
 	assert := assert.New(T)


### PR DESCRIPTION
As per the documentation, 2-legged OAuth2 is preferred if you're not running as a third party.  As this is a provided feature, it's simpler to set up and requires one less parameter.