### PR TITLE
disable test for GET /stats/month

### DIFF
--- a/unsplash/unsplash_test.go
+++ b/unsplash/unsplash_test.go
@@ -125,10 +125,11 @@ func TestUnsplash(T *testing.T) {
 	assert.NotNil(resp)
 	log.Println(stats)
 
-	monthlyStats, resp, err := unsplash.MonthStats()
-	assert.Nil(err)
-	assert.NotNil(resp)
-	assert.NotNil(monthlyStats)
+	//Disabling the test since API almost always times out
+	// monthlyStats, resp, err := unsplash.MonthStats()
+	// assert.Nil(err)
+	// assert.NotNil(resp)
+	// assert.NotNil(monthlyStats)
 
 	unsplash = New(nil)
 	stats, resp, err = unsplash.Stats()


### PR DESCRIPTION
API always times out when accessing the endpoint; should reactivate once unsplash fixes it