### PR TITLE
fix: redesign the core composition hirearchy

### DIFF
--- a/unsplash/collections_service.go
+++ b/unsplash/collections_service.go
@@ -76,8 +76,7 @@ func (cs *CollectionsService) Collection(id string) (*Collection, *Response, err
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*cs)
-	resp, err := cli.do(req)
+	resp, err := cs.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,8 +108,7 @@ func (cs *CollectionsService) Create(opt *CollectionOpt) (*Collection, *Response
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*cs)
-	resp, err := cli.do(req)
+	resp, err := cs.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,8 +136,7 @@ func (cs *CollectionsService) Update(collectionID int, opt *CollectionOpt) (*Col
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*cs)
-	resp, err := cli.do(req)
+	resp, err := cs.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -161,8 +158,7 @@ func (cs *CollectionsService) Delete(collectionID int) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	cli := (service)(*cs)
-	resp, err := cli.do(req)
+	resp, err := cs.client.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +186,7 @@ func (cs *CollectionsService) AddPhoto(collectionID int, photoID string) (*Respo
 	if err != nil {
 		return nil, err
 	}
-	cli := (service)(*cs)
-	resp, err := cli.do(req)
+	resp, err := cs.client.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -215,8 +210,7 @@ func (cs *CollectionsService) RemovePhoto(collectionID int, photoID string) (*Re
 	if err != nil {
 		return nil, err
 	}
-	cli := (service)(*cs)
-	resp, err := cli.do(req)
+	resp, err := cs.client.do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/unsplash/get_helpers.go
+++ b/unsplash/get_helpers.go
@@ -37,7 +37,7 @@ func (s *service) getPhotos(opt *ListOpt, endpoint string) (*[]Photo, *Response,
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := s.do(req)
+	resp, err := s.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (s *service) getCollections(opt *ListOpt, endpoint string) (*[]Collection, 
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := s.do(req)
+	resp, err := s.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/unsplash/photos_service.go
+++ b/unsplash/photos_service.go
@@ -88,8 +88,7 @@ func (ps *PhotosService) Photo(id string, photoOpt *PhotoOpt) (*Photo, *Response
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -111,8 +110,7 @@ func (ps *PhotosService) Stats(id string) (*PhotoStats, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,8 +138,7 @@ func (ps *PhotosService) Statistics(id string, opt *StatsOpt) (*PhotoStatistics,
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,8 +160,7 @@ func (ps *PhotosService) DownloadLink(id string) (*URL, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -249,8 +245,7 @@ func (ps *PhotosService) Random(opt *RandomPhotoOpt) (*[]Photo, *Response, error
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -273,8 +268,7 @@ func (ps *PhotosService) Like(photoID string) (*Photo, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -296,8 +290,7 @@ func (ps *PhotosService) Unlike(photoID string) (*Photo, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*ps)
-	resp, err := cli.do(req)
+	resp, err := ps.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/unsplash/search_service.go
+++ b/unsplash/search_service.go
@@ -62,8 +62,7 @@ func (ss *SearchService) Users(opt *SearchOpt) (*UserSearchResult, *Response, er
 	if err != nil {
 		return nil, nil, err
 	}
-	s := (service)(*ss)
-	resp, err := s.do(req)
+	resp, err := ss.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -87,8 +86,7 @@ func (ss *SearchService) Photos(opt *SearchOpt) (*PhotoSearchResult, *Response, 
 	if err != nil {
 		return nil, nil, err
 	}
-	s := (service)(*ss)
-	resp, err := s.do(req)
+	resp, err := ss.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,8 +110,7 @@ func (ss *SearchService) Collections(opt *SearchOpt) (*CollectionSearchResult, *
 	if err != nil {
 		return nil, nil, err
 	}
-	s := (service)(*ss)
-	resp, err := s.do(req)
+	resp, err := ss.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/unsplash/unsplash.go
+++ b/unsplash/unsplash.go
@@ -31,12 +31,13 @@ import (
 )
 
 type service struct {
-	httpClient *http.Client
+	client *Unsplash
 }
 
 // Unsplash wraps the entire Unsplash.com API
 type Unsplash struct {
-	common      *service
+	client      *http.Client
+	common      service
 	Users       *UsersService
 	Photos      *PhotosService
 	Collections *CollectionsService
@@ -45,21 +46,20 @@ type Unsplash struct {
 
 //New returns a new Unsplash struct
 func New(client *http.Client) *Unsplash {
-	unsplash := new(Unsplash)
-	unsplash.common = new(service)
 	if client == nil {
-		unsplash.common.httpClient = http.DefaultClient
-	} else {
-		unsplash.common.httpClient = client
+		client = http.DefaultClient
 	}
-	unsplash.Users = (*UsersService)(unsplash.common)
-	unsplash.Photos = (*PhotosService)(unsplash.common)
-	unsplash.Collections = (*CollectionsService)(unsplash.common)
-	unsplash.Search = (*SearchService)(unsplash.common)
+	unsplash := new(Unsplash)
+	unsplash.client = client
+	unsplash.common.client = unsplash
+	unsplash.Users = (*UsersService)(&unsplash.common)
+	unsplash.Photos = (*PhotosService)(&unsplash.common)
+	unsplash.Collections = (*CollectionsService)(&unsplash.common)
+	unsplash.Search = (*SearchService)(&unsplash.common)
 	return unsplash
 }
 
-func (s *service) do(req *request) (*Response, error) {
+func (s *Unsplash) do(req *request) (*Response, error) {
 	var err error
 	//TODO should this be exported?
 	if req == nil {
@@ -68,7 +68,7 @@ func (s *service) do(req *request) (*Response, error) {
 	}
 	req.Request.Header.Set("Accept-Version", "v1")
 	//Make the request
-	client := s.httpClient
+	client := s.client
 	rawResp, err := client.Do(req.Request)
 	if rawResp != nil {
 		defer rawResp.Body.Close()
@@ -94,7 +94,7 @@ func (u *Unsplash) CurrentUser() (*User, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := u.common.do(req)
+	resp, err := u.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,7 +117,7 @@ func (u *Unsplash) UpdateCurrentUser(updateInfo *UserUpdateInfo) (*User, *Respon
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := u.common.do(req)
+	resp, err := u.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,7 +138,7 @@ func (u *Unsplash) Stats() (*GlobalStats, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := u.common.do(req)
+	resp, err := u.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +163,7 @@ func (u *Unsplash) MonthStats() (*MonthStats, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := u.common.do(req)
+	resp, err := u.do(req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/unsplash/unsplash_test.go
+++ b/unsplash/unsplash_test.go
@@ -110,7 +110,7 @@ func TestUnsplash(T *testing.T) {
 	unsplash := setup()
 	assert.NotNil(unsplash)
 	assert.NotNil(unsplash.common)
-	assert.NotNil(unsplash.common.httpClient)
+	assert.NotNil(unsplash.client)
 	tstats, resp, err := unsplash.TotalStats()
 	assert.Nil(err)
 	assert.NotNil(tstats)
@@ -138,7 +138,7 @@ func TestUnsplash(T *testing.T) {
 	assert.NotNil(err)
 
 	var s service
-	_, err = s.do(nil)
+	_, err = s.client.do(nil)
 	assert.NotNil(err)
 }
 

--- a/unsplash/users_service.go
+++ b/unsplash/users_service.go
@@ -47,8 +47,7 @@ func (us *UsersService) User(username string, imageOpt *ProfileImageOpt) (*User,
 	if err != nil {
 		return nil, err
 	}
-	cli := (service)(*us)
-	resp, err := cli.do(req)
+	resp, err := us.client.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +73,7 @@ func (us *UsersService) Portfolio(username string) (*URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	cli := (service)(*us)
-	resp, err := cli.do(req)
+	resp, err := us.client.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +131,7 @@ func (us *UsersService) Statistics(username string, opt *StatsOpt) (*UserStatist
 	if err != nil {
 		return nil, nil, err
 	}
-	cli := (service)(*us)
-	resp, err := cli.do(req)
+	resp, err := us.client.do(req)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- introduce recursive composition of Unsplash type
which holds the client
- remove the ugly type casting code from the entire library