### PR TITLE
Add Alt Text, Tags and other fields

### DIFF
--- a/unsplash/photo.go
+++ b/unsplash/photo.go
@@ -38,13 +38,23 @@ type ExifData struct {
 	Iso          *int    `json:"iso"`
 }
 
+// Tag lists can be applied to any photo
+type Tag struct {
+	Type  *string `json:"type"`
+	Title *string `json:"title"`
+}
+
 // Photo represents a photo on unsplash.com
 type Photo struct {
 	ID           *string    `json:"id"`
 	CreatedAt    *time.Time `json:"created_at"`
+	UpdatedAt    *time.Time `json:"updated_at"`
 	Width        *int       `json:"width"`
 	Height       *int       `json:"height"`
 	Color        *string    `json:"color"`
+	Description  *string    `json:"description"`
+	AltText      *string    `json:"alt_description"`
+	Views        *int       `json:"views"`
 	Downloads    *int       `json:"downloads"`
 	Likes        *int       `json:"likes"`
 	LikedByUser  *bool      `json:"liked_by_user"`
@@ -60,6 +70,7 @@ type Photo struct {
 			Longitude *float64 `json:"longitude"`
 		} `json:"position"`
 	} `json:"location"`
+	Tags                   *[]Tag        `json:"tags"`
 	CurrentUserCollections *[]Collection `json:"current_user_collections"`
 	Urls                   *struct {
 		Raw     *URL `json:"raw"`

--- a/unsplash/photo.go
+++ b/unsplash/photo.go
@@ -46,21 +46,21 @@ type Tag struct {
 
 // Photo represents a photo on unsplash.com
 type Photo struct {
-	ID           *string    `json:"id"`
-	CreatedAt    *time.Time `json:"created_at"`
-	UpdatedAt    *time.Time `json:"updated_at"`
-	Width        *int       `json:"width"`
-	Height       *int       `json:"height"`
-	Color        *string    `json:"color"`
-	Description  *string    `json:"description"`
-	AltText      *string    `json:"alt_description"`
-	Views        *int       `json:"views"`
-	Downloads    *int       `json:"downloads"`
-	Likes        *int       `json:"likes"`
-	LikedByUser  *bool      `json:"liked_by_user"`
-	Exif         *ExifData  `json:"exif"`
-	Photographer *User      `json:"user"`
-	Location     *struct {
+	ID             *string    `json:"id"`
+	CreatedAt      *time.Time `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at"`
+	Width          *int       `json:"width"`
+	Height         *int       `json:"height"`
+	Color          *string    `json:"color"`
+	Description    *string    `json:"description"`
+	AltDescription *string    `json:"alt_description"`
+	Views          *int       `json:"views"`
+	Downloads      *int       `json:"downloads"`
+	Likes          *int       `json:"likes"`
+	LikedByUser    *bool      `json:"liked_by_user"`
+	Exif           *ExifData  `json:"exif"`
+	Photographer   *User      `json:"user"`
+	Location       *struct {
 		Title    *string `json:"title"`
 		Name     *string `json:"name"`
 		City     *string `json:"city"`

--- a/unsplash/user.go
+++ b/unsplash/user.go
@@ -76,6 +76,9 @@ type User struct {
 	Badge               *UserBadge    `json:"badge"`
 	Links               *UserLinks    `json:"links,omitempty"`
 	Photos              *[]Photo      `json:"photos"`
+	UpdatedAt           *string       `json:"updated_at"`
+	InstagramUsername   *string       `json:"instagram_username"`
+	TwitterUsername     *string       `json:"twitter_username"`
 }
 
 func (u *User) String() string {


### PR DESCRIPTION
Thank you for this convenient library.

I needed a few more fields unmarshalled from the API responses, so this PR adds them.

Note that the `tag` object in the API response can have an extensive `source` property which I did not include.  Nor did I attempt to exhaustively include all fields in all response types.