### PR TITLE
Add ability to just use client_id.

### DIFF
--- a/unsplash/unsplash.go
+++ b/unsplash/unsplash.go
@@ -25,6 +25,7 @@ package unsplash
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ type service struct {
 
 // Unsplash wraps the entire Unsplash.com API
 type Unsplash struct {
+	client_id   string
 	client      *http.Client
 	common      service
 	Users       *UsersService
@@ -59,6 +61,12 @@ func New(client *http.Client) *Unsplash {
 	return unsplash
 }
 
+func NewWithClientID(client *http.Client, client_id string) *Unsplash {
+	r := New(client)
+	r.client_id = client_id
+	return r
+}
+
 func (s *Unsplash) do(req *request) (*Response, error) {
 	var err error
 	//TODO should this be exported?
@@ -67,6 +75,9 @@ func (s *Unsplash) do(req *request) (*Response, error) {
 			&IllegalArgumentError{ErrString: "Request object cannot be nil"}
 	}
 	req.Request.Header.Set("Accept-Version", "v1")
+	if s.client_id != "" {
+		req.Request.Header.Set("Authorization", fmt.Sprintf("Client-ID %v", s.client_id))
+	}
 	//Make the request
 	client := s.client
 	rawResp, err := client.Do(req.Request)

--- a/unsplash/unsplash.go
+++ b/unsplash/unsplash.go
@@ -61,6 +61,9 @@ func New(client *http.Client) *Unsplash {
 	return unsplash
 }
 
+//New returns a new Unsplash struct using client_id for Authorization header
+//This will only enable API that do not require user level authorization, but
+//just application level.
 func NewWithClientID(client *http.Client, client_id string) *Unsplash {
 	r := New(client)
 	r.client_id = client_id

--- a/unsplash/unsplash_test.go
+++ b/unsplash/unsplash_test.go
@@ -29,8 +29,10 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -192,4 +194,34 @@ func TestUpdateCurrentUser(T *testing.T) {
 	assert.Nil(user)
 	assert.Nil(resp)
 	log.Println(err.Error())
+}
+
+func TestClientIDPropagation(T *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	expected_client_id := "HARDCODED_TEST"
+
+	httpmock.RegisterResponder("GET", getEndpoint(base)+getEndpoint(searchPhotos),
+		func(r *http.Request) (*http.Response, error) {
+			client_id_header := r.Header.Get("Authorization")
+
+			assert.Equal(T, fmt.Sprintf("Client-ID %v", expected_client_id), client_id_header)
+
+			return httpmock.NewStringResponse(200, `{"total":1,"total_pages":1,"results":[{"id":"eOLpJytrbsQ","created_at":"2014-11-18T14:35:36-05:00","width":4000,"height":3000,"color":"#A7A2A1","blur_hash":"LaLXMa9Fx[D%~q%MtQM|kDRjtRIU","likes":286,"liked_by_user":false,"description":"A man drinking a coffee.","user":{"id":"Ul0QVz12Goo","username":"ugmonk","name":"Jeff Sheldon","first_name":"Jeff","last_name":"Sheldon","instagram_username":"instantgrammer","twitter_username":"ugmonk","portfolio_url":"http://ugmonk.com/","profile_image":{"small":"https://images.unsplash.com/profile-1441298803695-accd94000cac?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=7cfe3b93750cb0c93e2f7caec08b5a41","medium":"https://images.unsplash.com/profile-1441298803695-accd94000cac?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=5a9dc749c43ce5bd60870b129a40902f","large":"https://images.unsplash.com/profile-1441298803695-accd94000cac?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=32085a077889586df88bfbe406692202"},"links":{"self":"https://api.unsplash.com/users/ugmonk","html":"http://unsplash.com/@ugmonk","photos":"https://api.unsplash.com/users/ugmonk/photos","likes":"https://api.unsplash.com/users/ugmonk/likes"}},"current_user_collections":[],"urls":{"raw":"https://images.unsplash.com/photo-1416339306562-f3d12fefd36f","full":"https://hd.unsplash.com/photo-1416339306562-f3d12fefd36f","regular":"https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=92f3e02f63678acc8416d044e189f515","small":"https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&s=263af33585f9d32af39d165b000845eb","thumb":"https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&s=8aae34cf35df31a592f0bef16e6342ef"},"links":{"self":"https://api.unsplash.com/photos/eOLpJytrbsQ","html":"http://unsplash.com/photos/eOLpJytrbsQ","download":"http://unsplash.com/photos/eOLpJytrbsQ/download"}}]}`), nil
+		})
+
+	u := NewWithClientID(&http.Client{Timeout: time.Duration(1) * time.Second}, expected_client_id)
+
+	opt := SearchOpt{
+		Page:    1,
+		PerPage: 1,
+		Query:   "nowhere",
+	}
+	photo, _, err := u.Search.Photos(&opt)
+	assert.Equal(T, nil, err)
+	assert.NotEqual(T, nil, photo)
+
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(T, 1, info[fmt.Sprintf("GET %v%v", getEndpoint(base), getEndpoint(searchPhotos))])
 }


### PR DESCRIPTION
A good number of unsplash API do not need to go through the oauth2 cycle. It simplify things a bit to use the access key as client_id directly.