### PR TITLE
add search options

### DIFF
--- a/unsplash/photo.go
+++ b/unsplash/photo.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-// ExifData for an image
+//ExifData for an image
 type ExifData struct {
 	Make         *string `json:"make"`
 	Model        *string `json:"model"`
@@ -54,7 +54,6 @@ type Photo struct {
 	Color          *string    `json:"color"`
 	Description    *string    `json:"description"`
 	AltDescription *string    `json:"alt_description"`
-	BlurHash       *string    `json:"blur_hash"`
 	Views          *int       `json:"views"`
 	Downloads      *int       `json:"downloads"`
 	Likes          *int       `json:"likes"`
@@ -100,7 +99,7 @@ func (p *Photo) String() string {
 	return buf.String()
 }
 
-// PhotoStats shows various stats of the photo returned by /photos/:id/stats endpoint
+//PhotoStats shows various stats of the photo returned by /photos/:id/stats endpoint
 type PhotoStats struct {
 	Downloads int `json:"downloads"`
 	Likes     int `json:"likes"`

--- a/unsplash/photo.go
+++ b/unsplash/photo.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-//ExifData for an image
+// ExifData for an image
 type ExifData struct {
 	Make         *string `json:"make"`
 	Model        *string `json:"model"`
@@ -54,6 +54,7 @@ type Photo struct {
 	Color          *string    `json:"color"`
 	Description    *string    `json:"description"`
 	AltDescription *string    `json:"alt_description"`
+	BlurHash       *string    `json:"blur_hash"`
 	Views          *int       `json:"views"`
 	Downloads      *int       `json:"downloads"`
 	Likes          *int       `json:"likes"`
@@ -99,7 +100,7 @@ func (p *Photo) String() string {
 	return buf.String()
 }
 
-//PhotoStats shows various stats of the photo returned by /photos/:id/stats endpoint
+// PhotoStats shows various stats of the photo returned by /photos/:id/stats endpoint
 type PhotoStats struct {
 	Downloads int `json:"downloads"`
 	Likes     int `json:"likes"`

--- a/unsplash/search_service.go
+++ b/unsplash/search_service.go
@@ -30,9 +30,11 @@ type SearchService service
 
 // SearchOpt should be used to query /search endpoint
 type SearchOpt struct {
-	Page    int    `url:"page"`
-	PerPage int    `url:"per_page"`
-	Query   string `url:"query"`
+	Page        int    `url:"page"`
+	PerPage     int    `url:"per_page"`
+	Query       string `url:"query"`
+	Color       string `url:"color,omitempty"`
+	Orientation string `url:"orientation,omitempty"`
 }
 
 // Valid validates a SearchOpt

--- a/unsplash/search_service.go
+++ b/unsplash/search_service.go
@@ -30,11 +30,11 @@ type SearchService service
 
 // SearchOpt should be used to query /search endpoint
 type SearchOpt struct {
-	Page        int    `url:"page"`
-	PerPage     int    `url:"per_page"`
-	Query       string `url:"query"`
-	Color       string `url:"color,omitempty"`
-	Orientation string `url:"orientation,omitempty"`
+	Page        int     `url:"page"`
+	PerPage     int     `url:"per_page"`
+	Query       string  `url:"query"`
+	Color       *string `url:"color,omitempty"`
+	Orientation *string `url:"orientation,omitempty"`
 }
 
 // Valid validates a SearchOpt


### PR DESCRIPTION
# Issue
The photo search api allows for color and landscape search options. 

## Solution
Allow for color string and landscape string.

### Note
The API specifies the enums. That wasn't included in this solution.